### PR TITLE
bug fix: StopWordsKorean class

### DIFF
--- a/newspaper/text.py
+++ b/newspaper/text.py
@@ -149,8 +149,8 @@ class StopWordsKorean(StopWords):
         c = 0
         for w in candidate_words:
             c += 1
-            for stop_word in self.STOP_WORDS:
-                overlapping_stopwords.append(stop_word)
+            if w in self.STOP_WORDS:
+                overlapping_stopwords.append(w)
 
         ws.set_word_count(c)
         ws.set_stopword_count(len(overlapping_stopwords))


### PR DESCRIPTION
fixed bug in StopWordsKorean class that original code did not find stopwords in words.
StopWordsHindi class also seems like having the same problem but did not fix it.